### PR TITLE
Load package.json fields from URL

### DIFF
--- a/src/util/fieldLoader.ts
+++ b/src/util/fieldLoader.ts
@@ -3,11 +3,18 @@
  */
 import { promises as fs } from 'fs';
 import path from 'path';
+import axios from 'axios';
 
-type CustomPath = string | undefined | null;
+// To avoid throwing errors with 404.
+axios.defaults.validateStatus = () => true;
 
 class FieldLoader {
-  async loadFields(customPath: CustomPath): Promise<Record<string, unknown>> {
+  /**
+   * Loads the package.json required fields as a JS object (default ./fields.json)
+   * @param customPath the path of the custom specified required fields (optional)
+   * @returns the required fields as a JS object
+   */
+  async loadFields(customPath?: string): Promise<Record<string, unknown>> {
     const location = customPath
       ? path.join(process.cwd(), customPath)
       : path.join(__dirname, 'fields.json');
@@ -15,6 +22,19 @@ class FieldLoader {
     const fieldsRaw = await fs.readFile(location, { encoding: 'utf-8' });
     const fields = JSON.parse(fieldsRaw);
     return fields;
+  }
+
+  /**
+   * Loads the package.json fields from a URL
+   * @param url the url that the package.json exists
+   * @returns the package.json fields as a JS object
+   */
+  async loadFieldsFromURL(url: string): Promise<Record<string, unknown>> {
+    const { status, data } = await axios.get(url);
+    if (status !== 200) {
+      throw Error('Package.json could not be fetched from URL');
+    }
+    return data;
   }
 }
 


### PR DESCRIPTION
This PR adds the functionality to field-loader module to fetch a package.json file from URL and parse to JS object.

solves #34 