### PR TITLE
src: adding a Report class do deal with cli-table3

### DIFF
--- a/src/commands/validatorCmd.ts
+++ b/src/commands/validatorCmd.ts
@@ -4,6 +4,8 @@
  */
 import * as yargs from 'yargs';
 import Validator from '../core/validator';
+import chalk from 'chalk';
+import Report from '../util/report';
 
 export const command = 'validate';
 
@@ -19,5 +21,14 @@ export const builder = {
 
 export const handler = async (argv: yargs.Arguments): Promise<void> => {
   const validator = new Validator();
-  validator.run(argv.organization as string);
+  const result = await validator.run(argv.organization as string);
+
+  console.log(`${chalk.bold('Oratrix report')}\n`);
+  // We need the required fields here:
+  // console.log(`${Report.createValidatorReport(null, result)}\n`);
+
+  if (result.length > 0) {
+    throw Error(`You have ${result.length} field(s) missing.`);
+  }
+  
 };

--- a/src/core/validator.ts
+++ b/src/core/validator.ts
@@ -1,5 +1,3 @@
-import Table from 'cli-table3';
-import chalk from 'chalk';
 import FieldLoader from '../util/fieldLoader';
 import Differ from '../util/differ';
 import GithubFetcher from '../util/githubFetcher';
@@ -8,49 +6,25 @@ class Validator {
   fieldLoader = new FieldLoader();
   differ = new Differ();
 
-  async run(organization?: string): Promise<void> {
+  async run(organization?: string): Promise<string[]> {
     if (organization) {
-      this.runOrganizationCheck(organization);
+      return this.runOrganizationCheck(organization);
     } else {
-      this.runLocalCheck();
+      return this.runLocalCheck();
     }
   }
 
-  async runLocalCheck(): Promise<void> {
+  async runLocalCheck(): Promise<string[]> {
     const requiredFields = await this.fieldLoader.loadFields();
     const packageFields = await this.fieldLoader.loadFields('./package.json');
-    // get report from differ
     const report = this.differ.run(requiredFields, packageFields);
-
-    // print report
-    const table = new Table({
-      head: ['Fields', 'Status'],
-      style: {
-        head: ['yellow'],
-      },
-    });
-
-    Object.keys(requiredFields).forEach((field) => {
-      const status =
-        report.indexOf(field) === -1
-          ? chalk.bgGreen.white(' PASS ')
-          : chalk.bgRed.white(' MISSING ');
-
-      table.push([field, status]);
-    });
-
-    console.log(`${chalk.bold('Oratrix report')}\n`);
-    console.log(`${table.toString()}\n`);
-
-    if (report.length > 0) {
-      throw Error(`You have ${report.length} field(s) missing.`);
-    }
+    return report;
   }
 
-  async runOrganizationCheck(organization: string): Promise<void> {
+  async runOrganizationCheck(organization: string): Promise<string[]> {
     const ghFetcher = new GithubFetcher();
     const result = await ghFetcher.fetch(organization);
-    console.log(result);
+    return result;
   }
 }
 

--- a/src/util/report.ts
+++ b/src/util/report.ts
@@ -1,0 +1,40 @@
+import Table from 'cli-table3';
+import chalk from 'chalk';
+
+/**
+ * This class is responsible to create stdout reports for the commands.
+ */
+export default class Report {
+  /**
+   * Creates a cli-table3 report for the validator command.
+   * @param tableData the data to be passed to cli-table3 to construct the report.
+   * @param requiredFields The fields considered required to have in package.json
+   */
+  static createValidatorReport(requiredFields: Record<string, unknown>, tableData: string[]): string {
+    // print report
+    const table = new Table({
+      head: ['Fields', 'Status'],
+      style: {
+        head: ['yellow'],
+      },
+    });
+
+    Object.keys(requiredFields).forEach((field) => {
+      const status =
+      tableData.indexOf(field) === -1
+          ? chalk.bgGreen.white(' PASS ')
+          : chalk.bgRed.white(' MISSING ');
+
+      table.push([field, status]);
+    });
+
+    return table.toString();
+
+    // console.log(`${chalk.bold('Oratrix report')}\n`);
+    // console.log(`${table.toString()}\n`);
+
+    // if (tableData.length > 0) {
+    //   throw Error(`You have ${tableData.length} field(s) missing.`);
+    // }
+  }
+}

--- a/test/core/validatorTest.ts
+++ b/test/core/validatorTest.ts
@@ -1,0 +1,17 @@
+import * as assert from 'assert';
+import Validator from '../../src/core/validator';
+
+const validator = new Validator();
+
+describe('A validator', () => {
+  it('Should return the validation data', async () => {
+    const result = await validator.run();
+    assert.ok(result.length > 0);
+  });
+
+  it('Should contain missing description field', async () => {
+    const result = await validator.run();
+    assert.strictEqual(result[0], 'description');
+  });
+
+});

--- a/test/util/reportTest.ts
+++ b/test/util/reportTest.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+import Report from '../../src/util/report';
+import FieldLoader from '../../src/util/fieldLoader';
+
+const fieldLoader = new FieldLoader();
+let requiredFields: Record<string, unknown>;
+
+before(async () => {
+  requiredFields = await fieldLoader.loadFields();
+});
+
+describe('A Report', () => {
+  it('Should create report for validator command', () => {
+    const tableDataTest = ['test'];
+    const result = Report.createValidatorReport(requiredFields, tableDataTest);
+    assert.ok(result.includes('Fields'));
+    assert.ok(result.includes('Status'));
+    assert.ok(result.includes('name'));
+    assert.ok(result.includes('version'));
+    assert.ok(result.includes('description'));
+    assert.ok(result.includes('author'));
+    assert.ok(result.includes('license'));
+    assert.ok(result.includes('dependencies'));
+    assert.ok(result.includes('devDependencies'));
+  });
+
+});


### PR DESCRIPTION
Refactor to introduce a Report class to deal with cli-table3 tables.
That is also enable us to easily write test to cover the reports and
core/business layer that don't need to deal with reporting data.