### PR TITLE
chore: add node 10.x to build matrix

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build"
   ],
   "engines": {
-    "node": ">=12"
+    "node": "^14 || ^12 || ^10"
   },
   "keywords": [],
   "author": "Red Hat, Inc.",


### PR DESCRIPTION
This is to keep same node versions accross nodeshift org on github
actions.