### PR TITLE
Target single repo for validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Oratrix
+
 ![Node.js CI](https://github.com/nodeshift/oratrix/workflows/Node.js%20CI/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/nodeshift/oratrix/badge.svg?branch=master)](https://coveralls.io/github/nodeshift/oratrix?branch=master)
 
@@ -21,7 +22,7 @@ $ npm install oratrix --save-dev
 
 // inside package.json
 scripts: {
-  "oratrix": "oratrix validate" 
+  "oratrix": "oratrix validate"
 }
 
 $ npm run oratrix
@@ -53,7 +54,7 @@ GitHub organization oratrix will validate
 
 GitHub's oAuth token oratrix will use when contacting GitHub's API
 
-**help** 
+**help**
 
 Shows the below help
 
@@ -70,7 +71,9 @@ Options:
 
   -o, --organization  GitHub organization oratrix will validate
 
+  -r, --repo          GitHub repository oratrix will validate
+
   -c, --config        Custom file with the required package.json fields
-  
+
   -t, --token         GitHub oauth token
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oratrix",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "CLI application for checking package.json consistency across repositories.",
   "main": "dist/cli.js",
   "bin": {

--- a/src/commands/validatorCmd.ts
+++ b/src/commands/validatorCmd.ts
@@ -18,6 +18,11 @@ export const builder = {
     describe: 'GitHub organization oratrix will validate',
     default: undefined,
   },
+  repo: {
+    alias: 'r',
+    describe: 'GitHub repository oratrix will validate',
+    default: undefined,
+  },
   config: {
     alias: 'c',
     describe: 'Custom file with the required package.json fields',
@@ -31,13 +36,15 @@ export const builder = {
 };
 
 export const handler = async (argv: yargs.Arguments): Promise<void> => {
-  const validatorOptions: Options = {
+  const options: Options = {
+    organization: argv.organization as string,
+    repo: argv.repo as string,
     config: argv.config as string,
     token: (argv.token as string) || (process.env.GITHUB_TOKEN as string),
   };
 
   try {
-    await validator.run(argv.organization as string, validatorOptions);
+    await validator.run(options);
   } catch (err) {
     console.log('\n', logSymbols.error, chalk.red.bold(err.message), '\n');
     process.exit(1);

--- a/test/core/validatorTest.ts
+++ b/test/core/validatorTest.ts
@@ -93,9 +93,15 @@ describe(`Validator`, () => {
     validator.__set__('runLocalCheck', runLocalCheckMock);
     validator.__set__('runOrganizationCheck', runOrgCheckMock);
 
-    await validator.default.run('nodeshift');
+    await validator.default.run({
+      organization: 'nodeshift',
+    });
     assert.ok(!runLocalCheckMock.called);
     assert.ok(runOrgCheckMock.called);
-    assert.ok(runOrgCheckMock.calledWith('nodeshift'));
+    assert.ok(
+      runOrgCheckMock.calledWith({
+        organization: 'nodeshift',
+      })
+    );
   });
 });


### PR DESCRIPTION
@helio-frota this PR adds the ability for oratrix to target a single repo (for validation) instead of the whole GitHub organization. #83 